### PR TITLE
Remove less template

### DIFF
--- a/django_base/settings.py
+++ b/django_base/settings.py
@@ -193,14 +193,8 @@ DEBUG_TOOLBAR_CONFIG = {
 
 ##### Static files #####
 
-LESS_TEMPLATE = """
-cd $(dirname {infile}); # Set working dir to that of the infile
-echo "@staticUrl: '%s'; $(cat {infile})" | # Inject STATIC_URL as @staticUrl
-lessc - {outfile} # Compile it
-"""
-
 COMPRESS_PRECOMPILERS = (
-    ('text/less', LESS_TEMPLATE % STATIC_URL),
+    ('text/less', 'lessc {infile} {outfile}'),
     ('text/coffeescript', 'coffee --compile --stdio'),
 )
 

--- a/django_base/settings.py
+++ b/django_base/settings.py
@@ -198,7 +198,7 @@ COMPRESS_PRECOMPILERS = (
     ('text/coffeescript', 'coffee --compile --stdio'),
 )
 
-COMPRESS_CSS_FILTER = (
+COMPRESS_CSS_FILTERS = (
     'compressor.filters.template.TemplateFilter',
 )
 


### PR DESCRIPTION
The LESS template can cause headaches, and there are better ways to inject a static url if one is needed (usually, relative paths are fine).
