### PR TITLE
Support web (JS / CSS) dependencies in pip-installable packages with jack-bower

### DIFF
--- a/project_name/bower.json
+++ b/project_name/bower.json
@@ -1,6 +1,7 @@
 {
     "name": "{{ project_name }}",
     "version": "0.0.0",
+    "ignore": ["**/*"],
     "dependencies": {
         "bootstrap": "2.3.2"
     }

--- a/project_name/settings/base.py
+++ b/project_name/settings/base.py
@@ -36,13 +36,15 @@ INSTALLED_APPS = (
     'django.contrib.messages',
     'django.contrib.staticfiles',
 
+    'bower',
     'django_versioned',
     'raven.contrib.django.raven_compat',
     'debug_toolbar',
     'compressor',
     'crispy_forms',
     'south',
-    '{{ project_name }}'
+
+    '{{ project_name }}',
 )
 
 MIDDLEWARE_CLASSES = (

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,6 +16,7 @@ django-versioned==0.3
 # Supporting dependencies
 Fabric==1.6.1
 boto==2.9.7
+git+https://github.com/SheepDogInc/jack-bower.git
 coverage==3.6
 gunicorn==17.5
 psycopg2==2.5.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ django-versioned==0.3
 # Supporting dependencies
 Fabric==1.6.1
 boto==2.9.7
-git+https://github.com/SheepDogInc/jack-bower.git
+jack-bower==0.1.5-sd
 coverage==3.6
 gunicorn==17.5
 psycopg2==2.5.1

--- a/setup.sh
+++ b/setup.sh
@@ -53,7 +53,7 @@ if ! grep -Fq "/node_modules/.bin" $VIRTUAL_ENV/bin/postactivate; then
     workon $PROJECT
 fi
 
-bower install
+./manage.py bower_install
 
 echo "============================"
 echo "TO PROCEED:"


### PR DESCRIPTION
This changeset adds support for pip-installable packages using jack-bower to manage installing dependencies from `bower.json` files located in apps added to INSTALLED_APPS. See [our copy of jack-bower](https://github.com/SheepDogInc/jack-bower) for more information.
